### PR TITLE
Fix context for json-ld

### DIFF
--- a/api/app/routers/sparql.py
+++ b/api/app/routers/sparql.py
@@ -111,10 +111,8 @@ async def run_sparql(request: Request, sparql_request: SPARQLRequest) -> SPARQLR
         if parsed_query.algebra.name == "AskQuery":
             result = "true" if qres.askAnswer else "false"
         elif serialization_format == "json-ld":
-            custom_context = {
-                "ex": "http://example.org#"  # Optional: set a default vocabular
-            }
-            result = qres.serialize(format=serialization_format, context=custom_context)
+            context = await get_context_from_prefixes_in_data(sparql_request.data)
+            result = qres.serialize(format=serialization_format, context=context)
         else:
             result = qres.serialize(format=serialization_format)
         return SPARQLResponse(
@@ -180,3 +178,17 @@ async def get_format_and_media_type_for_describe_construct(
         status_code=HTTPStatus.NOT_ACCEPTABLE,
         detail=f"Unsupported Accept header: {accept}",
     )
+
+
+async def get_context_from_prefixes_in_data(data: str) -> dict[str, str]:
+    """Get a JSON-LD context from the prefixes used in the data."""
+    # Add all prefixes used in the data and their corresponding URIs:
+    context = {}
+    for line in data.splitlines():
+        if line.strip().startswith("@prefix"):
+            parts = line.split()
+            if len(parts) >= 3:  # noqa: PLR2004 # pragma: no cover
+                prefix = parts[1].rstrip(":")
+                uri = parts[2].rstrip(".").strip("<>")
+                context[prefix] = uri
+    return context

--- a/api/tests/test_sparql.py
+++ b/api/tests/test_sparql.py
@@ -301,3 +301,36 @@ async def test_construct_query_unsupported_data_format() -> None:
             json={"query": query, "data": data},
         )
     assert response.status_code == HTTPStatus.NOT_ACCEPTABLE
+
+
+@pytest.mark.anyio
+async def test_json_ld_without_prefixes() -> None:
+    """Should return 200 OK and empty context."""
+    query = "CONSTRUCT {?s ?p ?o .} WHERE {?s ?p ?o .}"
+    data = """
+    <http://example.org#ex:Alice>
+        <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org#ex:Person>.
+	"""
+
+    headers = {"Accept": "application/ld+json"}
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        response = await ac.post(
+            "/sparql",
+            headers=headers,
+            json={"query": query, "data": data, "inference": False},
+        )
+    assert response.status_code == HTTPStatus.OK, response.json()
+    assert response.headers["content-type"] == "application/json"
+    data = response.json()
+    assert "length" in data
+    assert isinstance(data["length"], int)
+    assert data["length"] > 0
+    assert "result" in data
+    assert len(data["result"]) > 0
+    assert "result_content_type" in data
+    if not headers or "Accept" not in headers:
+        assert data["result_content_type"] == "text/turtle"
+    else:
+        assert data["result_content_type"] == headers["Accept"]


### PR DESCRIPTION
Resolves #21

Only add used prefixes to context. This is due to a [regression in rdflib](https://github.com/RDFLib/rdflib/issues/1679#issuecomment-1669907412)
